### PR TITLE
Add support for nebula and titan chains

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -39,5 +39,20 @@ module.exports = {
       url: "http://127.0.0.1:1248", // this is the RPC endpoint exposed by Frame
       timeout: 60000, // this is important, because otherwise the request can time out before you've reviewed and confirmed your transaction on the Ledger
     },
+    nebulaMainnet: {
+      chainId: 1482601649,
+      url: "http://127.0.0.1:1248", // this is the RPC endpoint exposed by Frame
+      timeout: 60000,
+    },
+    titanMainnet: {
+      chainId: 1350216234,
+      url: "http://127.0.0.1:1248", // this is the RPC endpoint exposed by Frame
+      timeout: 60000,
+    },
+    nebulaTestnet: {
+      chainId: 503129905,
+      url: "http://127.0.0.1:1248", // this is the RPC endpoint exposed by Frame
+      timeout: 60000,
+    },
   },
 };


### PR DESCRIPTION
Added hardhat support for titan mainnet, nebula mainnet and nebula testnet chain

## Nebula Mainnet deployment details
Add [Nebula mainnet](https://mainnet.skalenodes.com/#/chains/green-giddy-denebola) chain with following config in frame wallet:
 - Chain Name: `green-giddy-denebola`
 - ChainId: `1482601649`
 - Symbol: `sFUEL`
 - Block explorer: https://green-giddy-denebola.explorer.mainnet.skalenodes.com/
 - RPC Endpoint: https://mainnet.skalenodes.com/v1/green-giddy-denebola
 
**Deployment script**: `npx hardhat run scripts/deployBridge.js --network nebulaMainnet`
 
## Titan Mainnet deployment details
Add [Titan Mainnet](https://mainnet.skalenodes.com/#/chains/parallel-stormy-spica) chain with following config in frame wallet:
 - Chain Name: `parallel-stormy-spica`
 - ChainId: `1350216234`
 - Symbol: `sFUEL`
 - Block explorer: https://parallel-stormy-spica.explorer.mainnet.skalenodes.com/
 - RPC Endpoint: https://mainnet.skalenodes.com/v1/parallel-stormy-spica

**Deployment script**: `npx hardhat run scripts/deployBridge.js --network titanMainnet`


## Nebula Testnet deployment details
Add [Nebula Testnet](https://staging-v3.skalenodes.com/#/chains/staging-faint-slimy-achird) chain with following config in frame wallet:
 - Chain Name: `staging-faint-slimy-achird`
 - ChainId: `503129905`
 - Symbol: `sFUEL`
 - Block explorer: https://staging-faint-slimy-achird.explorer.staging-v3.skalenodes.com
 - RPC Endpoint:https://staging-v3.skalenodes.com/v1/staging-faint-slimy-achird

**Deployment script**: `npx hardhat run scripts/deployBridge.js --network nebulaTestnet`
