### PR TITLE
chore: deploy contracts on xdc testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ The above script will perform following operation:
 | TransparentForwarder | 0xe4371caE0ab6Fb4875BB1002c0230CB0a1423616 |
 | Staking              | 0x53Df936a3594777185DF12Cd073d9033cfF348D6 |
 
+### XDC Testnet (Apothem)
+
+| Contract             | Address                                    |
+| -------------------- | ------------------------------------------ |
+| ResultManager        | 0x03bD73afB6d3C5B86578010C099E5474aF1aABeF |
+| Forwarder            | 0xe4371caE0ab6Fb4875BB1002c0230CB0a1423616 |
+| TransparentForwarder | 0x53Df936a3594777185DF12Cd073d9033cfF348D6 |
+| Staking              | 0x7f80398840d1be49dd99609abe405034bf97e97a |
+
 ## Adding a New Network to Bridge
 
 ### 1. Update Hardhat Configuration

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -59,6 +59,11 @@ module.exports = {
       url: "http://127.0.0.1:1248", // this is the RPC endpoint exposed by Frame
       timeout: 60000,
     },
+    xdcTestnet: {
+      chainId: 51,
+      url: "https://erpc.apothem.network",
+      timeout: 60000,
+    },
   },
   gasReporter: {
     enabled: true,


### PR DESCRIPTION
# Problem Statement
Deploy contracts on xdc-testnet (Apothem Network)

# Solution
Deployed contracts on xdc-testnet (Apothem Network) by adding network config in `hardhat.config.js` and running `deployBridge.js` script

# Testing
Tested by deploying dummy client contract. Was able to access datafeeds.

